### PR TITLE
Fix clearing liked songs

### DIFF
--- a/spotify.companion/Api/Spotify/Data/Playlist.cs
+++ b/spotify.companion/Api/Spotify/Data/Playlist.cs
@@ -106,67 +106,11 @@ namespace spotify.companion.Api.Spotify.Data
         public static async Task<List<string>> GetTracksIdsAsync(SpotifyClient SpotifyClient, string id)
         {
             return await GetTracksPropAsync(SpotifyClient, id, "id");
-            //PlaylistGetItemsRequest request = new();
-            //request.Fields.Add("items(track(id, type))");
-
-            //try
-            //{
-            //    List<string> ids = new();
-            //    var page = await SpotifyClient.Playlists.GetItems(id, request);
-
-            //    await foreach (var item in SpotifyClient.Paginate(page))
-            //    {
-            //        if (item.Track is FullTrack fullTrack)
-            //            ids.Add(fullTrack.Id);
-            //    }
-
-            //    return ids;
-            //}
-            //catch (Exception)
-            //{
-            //    HandleError(SpotifyClient);
-            //    return null;
-            //}
         }
 
         public static async Task<List<string>> GetTracksUrisAsync(SpotifyClient SpotifyClient, string id)
         {
             return await GetTracksPropAsync(SpotifyClient, id, "uri");
-            //PlaylistGetItemsRequest request = new();
-            //request.Fields.Add("items(track(uri, type)), next");
-
-            //try
-            //{
-            //    List<string> uris = new();
-            //    var page = await SpotifyClient.Playlists.GetItems(id, request);
-
-            //    Action<Paging<PlaylistTrack<IPlayableItem>>> processPage = new(async(page) =>
-            //    {
-            //        string uri;
-            //        await foreach (var item in SpotifyClient.Paginate(page))
-            //        {
-            //            if (item.Track is FullTrack fullTrack)
-            //            {
-            //                uri = fullTrack.Uri;
-            //                if (!uris.Contains(uri)) uris.Add(uri);
-            //            }
-            //        }
-            //    });
-
-            //    while (page != null)
-            //    {
-            //        processPage(page);
-            //        if (page.Next == null) break;
-            //        page = await SpotifyClient.NextPage(page);
-            //    }
-
-            //    return uris;
-            //}
-            //catch (Exception)
-            //{
-            //    HandleError(SpotifyClient);
-            //    return null;
-            //}
         }
 
         private static async Task<List<string>> GetTracksPropAsync(SpotifyClient SpotifyClient, string id, string prop)

--- a/spotify.companion/Broker/DataBroker.cs
+++ b/spotify.companion/Broker/DataBroker.cs
@@ -183,7 +183,32 @@ namespace spotify.companion.Broker
 
             if (ids == null || ids.Count == 0) return false;
 
-            return await Api.Spotify.Data.Playlist.RemoveLikedAsync(SpotifyClient, ids);
+            //'Max 50 IDs at once'
+            bool result = false;
+
+            if (ids.Count < 50)
+            {
+                await Api.Spotify.Data.Playlist.RemoveLikedAsync(SpotifyClient, ids);
+            }
+            else
+            {
+                int index = 0;
+                int count = 50;
+                int max = ids.Count;
+                int sum = max;
+
+                List<string> temp;
+                while (index < max)
+                {
+                    temp = ids.GetRange(index, count);
+                    result = await Api.Spotify.Data.Playlist.RemoveLikedAsync(SpotifyClient, temp); ;
+                    index += count;
+                    sum -= count;
+                    if (sum <= 50) count = sum;
+                }
+            }
+
+            return result;
         }
 
         public static async Task<List<TrackCompareItem>> GetTracksToCompareAsync(string id)


### PR DESCRIPTION
You can only remove 50 songs at a time, otherwise it throws an error.